### PR TITLE
add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+Do you want to request a feature or report a bug?
+
+What is the current behavior?
+
+If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via [repl][repl].
+
+What is the expected behavior?
+
+Which versions of flask-raise, and which browser / OS are affected by this issue? Did this work in previous versions of flask-raise?
+
+[repl]: http://repl.it
+
+NB: You can drop a comment below for more clarification

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### What Does This PR Do?
+
+#### Description Of Task To Be Completed
+
+#### Any Background Context You Want To Provide?
+N/A
+
+#### How can this be manually tested?
+
+#### Screenshot(s)
+N/A
+
+#### What are the relevant github issues?


### PR DESCRIPTION
## What Does this PR do?
It adds the template for raising Pull requests and Github issues to the `Post-It` repository.

## Description of task to be completed
Add Markdown templates to a `.github` directory.